### PR TITLE
Update Cargo.toml to point to crates.io lcd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 
 [dependencies]
 i2cdev = "0.5.0"
-lcd = { git = "https://github.com/wfraser/lcd", rev = "b62212d7441f916a9fcef7dad01279a30dcff6f8" }
+lcd = "0.4.1"


### PR DESCRIPTION
Now that https://github.com/idubrov/lcd/pull/1 has merged, `Cargo.toml` can be updated to point to crates.io